### PR TITLE
Avoid setAttribute for CSP compliance

### DIFF
--- a/assets/javascripts/materialize.js
+++ b/assets/javascripts/materialize.js
@@ -4825,6 +4825,15 @@ $jscomp.polyfill = function (e, r, p, m) {
     return style;
   }
 
+  function setStyle(obj, style) {
+    if (M.jQueryLoaded) {
+      $( obj ).css(style);
+    }
+    else {
+      obj.setAttribute('style', convertStyle(style));
+    }
+  }
+
   var Effect = {
 
     // Effect delay
@@ -4869,7 +4878,7 @@ $jscomp.polyfill = function (e, r, p, m) {
       };
 
       ripple.className = ripple.className + ' waves-notransition';
-      ripple.setAttribute('style', convertStyle(rippleStyle));
+      setStyle(ripple, rippleStyle);
       ripple.className = ripple.className.replace('waves-notransition', '');
 
       // Scale the ripple
@@ -4890,7 +4899,7 @@ $jscomp.polyfill = function (e, r, p, m) {
       rippleStyle['-o-transition-timing-function'] = 'cubic-bezier(0.250, 0.460, 0.450, 0.940)';
       rippleStyle['transition-timing-function'] = 'cubic-bezier(0.250, 0.460, 0.450, 0.940)';
 
-      ripple.setAttribute('style', convertStyle(rippleStyle));
+      setStyle(ripple, rippleStyle);
     },
 
     hide: function (e) {
@@ -4939,7 +4948,7 @@ $jscomp.polyfill = function (e, r, p, m) {
           'transform': scale
         };
 
-        ripple.setAttribute('style', convertStyle(style));
+        setStyle(ripple, style);
 
         setTimeout(function () {
           try {
@@ -4974,7 +4983,7 @@ $jscomp.polyfill = function (e, r, p, m) {
             elementStyle = '';
           }
 
-          wrapper.setAttribute('style', elementStyle);
+          setStyle(wrapper, elementStyle);
 
           el.className = 'waves-button-input';
           el.removeAttribute('style');

--- a/assets/javascripts/materialize/waves.js
+++ b/assets/javascripts/materialize/waves.js
@@ -52,6 +52,16 @@
         return style;
     }
 
+    function setStyle(obj, style) {
+      if (M.jQueryLoaded) {
+        $( obj ).css(style);
+      }
+      else {
+        obj.setAttribute('style', convertStyle(style));
+      }
+    }
+
+
     var Effect = {
 
         // Effect delay
@@ -96,7 +106,7 @@
             };
 
             ripple.className = ripple.className + ' waves-notransition';
-            ripple.setAttribute('style', convertStyle(rippleStyle));
+            setStyle(ripple, rippleStyle);
             ripple.className = ripple.className.replace('waves-notransition', '');
 
             // Scale the ripple
@@ -117,7 +127,7 @@
             rippleStyle['-o-transition-timing-function'] = 'cubic-bezier(0.250, 0.460, 0.450, 0.940)';
             rippleStyle['transition-timing-function'] = 'cubic-bezier(0.250, 0.460, 0.450, 0.940)';
 
-            ripple.setAttribute('style', convertStyle(rippleStyle));
+            setStyle(ripple, rippleStyle);
         },
 
         hide: function (e) {
@@ -166,7 +176,7 @@
                     'transform': scale
                 };
 
-                ripple.setAttribute('style', convertStyle(style));
+                setStyle(ripple, style);
 
                 setTimeout(function () {
                     try {
@@ -201,7 +211,7 @@
                         elementStyle = '';
                     }
 
-                    wrapper.setAttribute('style', elementStyle);
+                    setStyle(wrapper, elementStyle);
 
                     el.className = 'waves-button-input';
                     el.removeAttribute('style');


### PR DESCRIPTION
We're using materialize-sass with Rails with a strict CSP config. Using `setAttribute('style', style)` causes issues the style policy. `element.style = ...` is CSP compliant and could be used instead. jQuery offers `.css()`, which uses the aforementioned `.style`.
This PR changes the problematic `setAttribute` calls to using a `setStyle()` function which checks if jQuery is loaded and uses `.css()` if possible or falls back to `setAttribute`.
It might be possible to enhance the function to fall back to looping through the styles and directly applying them with `.style = `, but I didn't look into that yet.

Using this PR with appropriate settings in Rails' `content_security_policy.rb` at least fixed all the CSP conflicts we had with materialize-sass.